### PR TITLE
zdb: wait on namespace lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ completed or waiting some time before flushing pending changes to the backend.
 Only `libfuse3` and `hiredis` are required to build `zdbfs`, on Linux.
 Note that, only `gcc` or `clang` are supported as C compiler.
 
+# Build
+
+You can build a debug version with simple `make` command.
+
+To produce a release version (no debug message), you can use `make release` command.
+
 # Options
 
 You can configure zdbfs via runtime arguments to pass via `-o` during mount, eg: `zdbfs -o mh=1.1.1.1,ts=newpwd /mnt/temp`
@@ -58,12 +64,33 @@ tn=zdbfs-temp       temporary namespace name
 ts=hello            temporary namespace password (mandatory)
 
 nocache             disable runtime cache (for debug purpose)
+autons              try to create required namespace on runtime
 ```
 
 # Quick Setup
 
-To get `zdbfs` to work out-of-box using a local 0-db (in sequential mode), prepare required namespaces:
+## Automatic
 
+Start a 0-db locally, in sequential mode:
+```
+zdb --mode seq
+```
+
+Then start `zdbfs` with `autons` option, to mount filesystem on `/mnt/zdbfs`:
+```
+./zdbfs -o autons /mnt/zdbfs
+```
+
+That's it.
+
+## Manual
+
+Start a 0-db locally, in sequential mode:
+```
+zdb --mode seq
+```
+
+Then create required namespaces:
 ```
 cat << EOF | redis-cli -p 9900
 NSNEW zdbfs-meta

--- a/src/zdbfs.c
+++ b/src/zdbfs.c
@@ -207,13 +207,13 @@ static void zdbfs_fuse_create(fuse_req_t req, fuse_ino_t parent, const char *nam
     // new file
     create = zdbfs_inode_new_file(req, mode);
     if((ino = zdbfs_inode_store_metadata(req, create, 0)) == 0)
-        dies("create", "could not create inode");
+        return zdbfs_fuse_error(req, EIO, parent);
 
     // update directory with new entry
     zdbfs_inode_dir_append(inode, ino, name);
 
     if(zdbfs_inode_store_metadata(req, inode, parent) != parent)
-        dies("create", "could not update parent directory");
+        return zdbfs_fuse_error(req, EIO, parent);
 
     zdbfs_inode_to_fuse_param(&e, create, ino);
     fuse_reply_create(req, &e, fi);


### PR DESCRIPTION
If 0-db namespace are write lock, block wait for namespace to be available again.
This also fix a hard crash on `create()` error.

Unlock is checked every 100ms. Better handling could maybe used, but nothing clean yet.

This closes #8 