### PR TITLE
log: implement operation log to logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ ts=hello            temporary namespace password (mandatory)
 
 nocache             disable runtime cache (for debug purpose)
 autons              try to create required namespace on runtime
+background          run in background when filesystem is ready
+logfile=(not set)   write operations to specified logfile
+                    note: this make lot of resolv request and can
+                    reduce performance, this could generate large logfile
+                    aswell if you do lot of operations
 ```
 
 # Quick Setup

--- a/src/inode.c
+++ b/src/inode.c
@@ -578,7 +578,6 @@ zdb_inode_t *zdbfs_directory_fetch(fuse_req_t req, fuse_ino_t ino) {
     // checking if this inode is a directory
     if(!S_ISDIR(inode->mode)) {
         zdbfs_debug("[-] directory: %lu: not a directory\n", ino);
-        zdbfs_inode_free(inode);
         fuse_reply_err(req, ENOTDIR);
         return NULL;
     }

--- a/src/inode.h
+++ b/src/inode.h
@@ -51,4 +51,6 @@
     uint32_t zdbfs_inode_store_backend(redisContext *backend, zdb_inode_t *inode, uint32_t ino);
     uint32_t zdbfs_inode_store_metadata(fuse_req_t req, zdb_inode_t *inode, uint32_t ino);
     uint32_t zdbfs_inode_store_data(fuse_req_t req, zdb_inode_t *inode, uint32_t ino);
+
+    char *zdbfs_inode_resolv(fuse_req_t req, fuse_ino_t target, const char *name);
 #endif

--- a/src/zdbfs.h
+++ b/src/zdbfs.h
@@ -173,6 +173,7 @@
         int nocache;          // runtime cache disabled
         int background;       // fork to background
         int autons;           // runtime namespace create
+        char *logfile;        // logfile where logging actions
 
     } zdbfs_options;
 
@@ -190,6 +191,8 @@
         int background;           // fork to background
         int caching;              // flag to enable runtime cache
         int autons;               // flag to create namespace on init
+        char *logfile;            // global logfile where to log actions
+        FILE *logfd;              // log file descriptor
         stats_t stats;            // global statistics
 
         zdbfs_options *opts;


### PR DESCRIPTION
Add a optional new option `logfile` with a filename.
Will log some operations (`create`, `mkdir`, `unlink`, ...) to this file.