### PR TITLE
cleanup: flush temporary namespace when possible

### DIFF
--- a/src/zdb.c
+++ b/src/zdb.c
@@ -67,6 +67,28 @@ int zdb_nsnew(redisContext *remote, char *namespace) {
     return 0;
 }
 
+int zdb_flush(redisContext *remote) {
+    const char *argv[] = {"FLUSH"};
+    redisReply *reply;
+
+    zdbfs_debug("[+] zdb: flush: namespace: %p\n", remote);
+
+    if(!(reply = redisCommandArgv(remote, 1, argv, NULL))) {
+        zdbfs_critical("zdb: flush: %p: %s", remote, remote->errstr);
+        return 1;
+    }
+
+    if(strcmp(reply->str, "OK") != 0) {
+        zdbfs_error("zdb: flush: %p: %s", remote, reply->str);
+        freeReplyObject(reply);
+        return 1;
+    }
+
+    freeReplyObject(reply);
+
+    return 0;
+}
+
 int zdb_nsset(redisContext *remote, char *namespace, char *setting, char *value) {
     const char *argv[] = {"NSSET", namespace, setting, value};
     int argc = 4;

--- a/src/zdb.h
+++ b/src/zdb.h
@@ -12,6 +12,7 @@
     int zdbfs_zdb_connect(zdbfs_t *fs);
     void zdbfs_zdb_free(zdbfs_t *fs);
 
+    int zdb_flush(redisContext *remote);
     zdb_reply_t *zdb_get(redisContext *remote, uint32_t id);
     uint32_t zdb_set(redisContext *remote, uint32_t id, const void *buffer, size_t length);
     int zdb_del(redisContext *remote, uint32_t id);

--- a/src/zdb.h
+++ b/src/zdb.h
@@ -6,6 +6,7 @@
     typedef struct zdb_nsinfo_t {
         size_t entries;
         size_t datasize;
+        size_t nextid;
 
     } zdb_nsinfo_t;
 


### PR DESCRIPTION
One namespace is dedicated as « temporary space » where some blocks are flushed to keep in memory cache not too high (when blocks should not be pushed to backend already, to avoid too-many-updates).

This namespace already proof it's utility but were used without management. This pull request add some management to keep the namespace under control. The namespace is not flushed as soon as possible but only when few data were already in.

There is no hard size limit, which can potentially lead to some problem later but at least this namespace doesn't grow without any limit anymore now.

The flush is not made too often to avoid too many disk operations and reduce delay.